### PR TITLE
feat: admin functionality - disable user

### DIFF
--- a/breeze/services/admin_service.py
+++ b/breeze/services/admin_service.py
@@ -70,13 +70,14 @@ class AdminService:
                 print_system_message(f"Username '{user_input}' not found! Please try again")
             else:
                 user_to_disable = self.auth_service.get_all_users().get(user_input) # get the user by username
-                if user_to_disable.get_is_disabled(): 
+                if user_to_disable.get_role() == "Admin":
+                    print_system_message("You cannot disable this account.")
+                elif user_to_disable.get_is_disabled(): 
                     print_system_message(f"The account '{user_input}' is already disabled.")
                 else:  
                     user_to_disable.set_is_disabled(True) # disable the user
                     self.auth_service.save_data_to_file() # save the change
                     print_system_message(f"The account '{user_input}' has been successfully disabled.")
-                break
                 
         direct_to_dashboard()
         

--- a/breeze/services/admin_service.py
+++ b/breeze/services/admin_service.py
@@ -19,12 +19,11 @@ class AdminService:
         print(ADMIN_BANNER_STRING)
         print('Hi', user.get_username(), '!')
         print('What do you want to do today?')
-
         
         print('[A] Allocate patient to MHWP')
         print('[E] Edit user information')
-        print('[R] Delete a user')
-        print('[D] Disable a user')
+        print('[D] Delete a user')
+        print('[I] Disable a user')
         print('[V] View summary')
         print('[X] Log out')
 
@@ -36,8 +35,8 @@ class AdminService:
                 self.edit_user_information()
             case "d":
                 self.delete_user()
-            case "r":
-                self.disable_user()
+            case "i":
+                self.disable_user(user)
             case "v":
                 self.view_summary()
             case "x":
@@ -56,9 +55,59 @@ class AdminService:
     def delete_user(self):
         pass
 
-    def disable_user(self):
-        pass
-
+    def disable_user(self, user):
+        clear_screen()
+        print(ADMIN_BANNER_STRING)
+        print(f'Hi {user.get_username()} ! Here are all the users:')
+        self._print_users_with_disabled_status()
+        
+        while True:
+            print("Enter the username of the account that you want to disable (case insensitive), or press [R] to cancel:")        
+            user_input = input("> ").strip().lower()
+            if user_input == "r":
+                break
+            elif not user_input in self.auth_service.get_all_users(): # TODO: not allow user with username r.
+                print_system_message(f"Username '{user_input}' not found! Please try again")
+            else:
+                user_to_disable = self.auth_service.get_all_users().get(user_input) # get the user by username
+                if user_to_disable.get_is_disabled(): 
+                    print_system_message(f"The account '{user_input}' is already disabled.")
+                else:  
+                    user_to_disable.set_is_disabled(True) # disable the user
+                    self.auth_service.save_data_to_file() # save the change
+                    print_system_message(f"The account '{user_input}' has been successfully disabled.")
+                break
+                
+        direct_to_dashboard()
+        
     def view_summary(self):
         pass
 
+    def _print_users_with_disabled_status(self):
+        """Private method that prints a list of all users and their account disabled status.
+        
+        This method is intended for AdminService class only and is responsible for displaying
+        usernames, their roles, and whether their accounts are disabled. It excludes 
+        users with the 'Admin' role from the list.
+
+        Only the status of disabled accounts is shown for each user.
+
+        Note:
+            This is a private method and should not be accessed directly outside of 
+            this class.
+        """
+        users = self.auth_service.get_all_users().values()
+        
+        print("-" * 65)  
+        print(f"| {'Username':<20} | {'Role':<15} | {'Is Account Disabled':<20} |")
+        print("-" * 65)  
+
+        # Print each user's details with vertical lines
+        for user in users:
+            if not user.get_role() == 'Admin':
+                username = user.get_username()
+                role = user.get_role()
+                is_account_disabled = "True" if user.get_is_disabled() else "False"
+                print(f"| {username:<20} | {role:<15} | {is_account_disabled:<20} |")
+        
+        print("-" * 65)  

--- a/breeze/services/auth_service.py
+++ b/breeze/services/auth_service.py
@@ -78,4 +78,5 @@ class AuthService:
         print_system_message("Account created successfully! Press B to go back and log in.")
         return new_user
 
-    
+    def get_all_users(self):
+        return self.users

--- a/breeze/services/mhwp_service.py
+++ b/breeze/services/mhwp_service.py
@@ -1,4 +1,4 @@
-from breeze.utils.cli_utils import print_system_message, clear_screen, direct_to_dashboard
+from breeze.utils.cli_utils import print_system_message, clear_screen, direct_to_dashboard, show_disabled_account_dashboard_menu
 from breeze.utils.constants import MHWP_BANNER_STRING
 
 class MHWPService:
@@ -15,33 +15,35 @@ class MHWPService:
         Returns:
             bool: True if the user chose to log out, otherwise False
         """
-    
-    
-        print(MHWP_BANNER_STRING)
-        print('Hi', user.get_username(), '!')
-        print('What do you want to do today?')
-
         
-        print("[C] View Calendar of Appointments")
-        print("[M] Manage Appointments (Confirm or Cancel)")
-        print("[A] Add Patient Information (Condition, Notes)")
-        print("[D] Display Patient Summary with Mood Chart")
-        print("[X] Log out")
+        print(MHWP_BANNER_STRING)
+        
+        if user.get_is_disabled():
+            return show_disabled_account_dashboard_menu(user.get_username())
+            
+        else:
+            print('Hi', user.get_username(), '!')
+            print('What do you want to do today?')        
+            print("[C] View Calendar of Appointments")
+            print("[M] Manage Appointments (Confirm or Cancel)")
+            print("[A] Add Patient Information (Condition, Notes)")
+            print("[D] Display Patient Summary with Mood Chart")
+            print("[X] Log out")
 
-        user_input = input("> ").strip().lower()
-        match user_input:
-            case "c":
-                self.view_calendar(user)
-            case "m":
-                self.manage_appointments(user)
-            case "a":
-                self.add_patient_information(user)
-            case "d":
-                self.display_patient_summary(user)
-            case "x":
-                return True 
-            case _:
-                print_system_message("Invalid choice. Please try again.")
+            user_input = input("> ").strip().lower()
+            match user_input:
+                case "c":
+                    self.view_calendar(user)
+                case "m":
+                    self.manage_appointments(user)
+                case "a":
+                    self.add_patient_information(user)
+                case "d":
+                    self.display_patient_summary(user)
+                case "x":
+                    return True 
+                case _:
+                    print_system_message("Invalid choice. Please try again.")
 
         return False
 

--- a/breeze/services/patient_service.py
+++ b/breeze/services/patient_service.py
@@ -1,4 +1,4 @@
-from breeze.utils.cli_utils import print_system_message, clear_screen, direct_to_dashboard
+from breeze.utils.cli_utils import print_system_message, clear_screen, direct_to_dashboard, show_disabled_account_dashboard_menu
 from breeze.utils.constants import PATIENT_BANNER_STRING
 
 class PatientService:
@@ -10,35 +10,40 @@ class PatientService:
 
         Args:
             user (User): _The logged-in user
-            
+
         Returns:
             bool: True if the user chose to log out, otherwise False
         """
-        #clear_screen()
+        
         print(PATIENT_BANNER_STRING)
-        print('Hi', user.get_username(), '!')
-        print('What do you want to do today?')
         
-        print("[E] Edit my personal information")
-        print("[R] Record my mood for today")
-        print("[J] Journal - enter your journaling text")
-        print("[S] Search for meditation and relaxation exercises")
-        print("[B] Book or cancel an appointment with my MHWP")
-        print("[X] Log out")
-        
-        user_input = input('> ')
-        match user_input.strip().lower():
-            case "e":
-                self.edit_personal_information(user)
-            case "x":
-                return True
-            case "s":
-                self.search_exercise(user)
-            case _:
-                pass
-        
+        if user.get_is_disabled():
+            return show_disabled_account_dashboard_menu(user.get_username())
+             
+        else:
+            # If account is not disabled, show the full list of options
+            print('Hi', user.get_username(), '!')
+            print('What do you want to do today?')
+            print("[E] Edit my personal information")
+            print("[R] Record my mood for today")
+            print("[J] Journal - enter your journaling text")
+            print("[S] Search for meditation and relaxation exercises")
+            print("[B] Book or cancel an appointment with my MHWP")
+            print("[X] Log out")
+
+            user_input = input('> ')
+            match user_input.strip().lower():
+                case "e":
+                    self.edit_personal_information(user)
+                case "s":
+                    self.search_exercise(user)
+                case "x":
+                    return True
+                case _:
+                    print_system_message("Invalid choice. Please try again.")
+
         return False
-    
+
     def edit_personal_information(self, user):
         clear_screen()
         print(PATIENT_BANNER_STRING)

--- a/breeze/utils/cli_utils.py
+++ b/breeze/utils/cli_utils.py
@@ -22,6 +22,26 @@ def print_system_message(message):
 def clear_screen():
     os.system('cls' if os.name == 'nt' else 'clear')
     
+def show_disabled_account_dashboard_menu(username):
+    """
+    Prompts the user with a message when their account is disabled.
+    
+    Args:
+        user (User): The user whose account is disabled.
+        
+    Returns:
+        bool: True if the user chose to log out, otherwise False.
+    """
+    print_system_message(f'Hi {username}, your account has been disabled, please contact the admin for more info!')
+    print("[X] Log out")
+            
+    user_input = input('> ')
+    if user_input.strip().lower() == "x":
+        return True
+    else:
+        print_system_message("Sorry, you can only log out because your account is disabled.")
+        return False
+
 def direct_to_dashboard():
     print("\nPress B to go back:")
     while True:


### PR DESCRIPTION
In Admin Dashboard:
- Change the key for disabling a user from `r` to `i` (since `r` is reserved for "return").
- Created `_print_users_with_disabled_status` in the `adminService` class as a private method, since it's only used by the `adminService` to show account status.
   -  it will not show admin account
- Not allow to delete admin account

In Patient and GP Dashboards:
- Only display the "Log out" option if the current user's account is disabled.
- Create a function `show_disabled_account_dashboard_menu` to handle this behavior, making it reusable.
