### PR TITLE
feat: GP can confirm/cancel appointment + patient can book/cancel appoint using the current calendar

### DIFF
--- a/breeze/models/appointment_entry.py
+++ b/breeze/models/appointment_entry.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, time, date
 
 
 class AppointmentEntry:
@@ -23,12 +23,17 @@ class AppointmentEntry:
             status (str): The status of the appointment (e.g., "requested", "confirmed", "cancelled").
         """
         self.appointment_id = appointment_id or str(uuid.uuid4())
-        self.date = datetime.strptime(
-            date_str, "%Y-%m-%d"
-        ).date()  # Store as datetime.date
-        self.time = datetime.strptime(
-            time_str, "%I:%M %p"
-        ).time()  # Store as datetime.time
+        # Handle date input
+        if isinstance(date_str, date):
+            self.date = date_str
+        else:
+            self.date = datetime.strptime(date_str, "%Y-%m-%d").date()
+        
+        # Handle time input
+        if isinstance(time_str, time):
+            self.time = time_str
+        else:
+            self.time = datetime.strptime(time_str, "%I:%M %p").time()
         self.mhwp_username = mhwp_username
         self.patient_username = patient_username
         self.isCancelled = isCancelled

--- a/breeze/models/appointment_entry.py
+++ b/breeze/models/appointment_entry.py
@@ -28,7 +28,7 @@ class AppointmentEntry:
             self.date = date_str
         else:
             self.date = datetime.strptime(date_str, "%Y-%m-%d").date()
-        
+
         # Handle time input
         if isinstance(time_str, time):
             self.time = time_str
@@ -65,12 +65,14 @@ class AppointmentEntry:
         """
         Marks the appointment as confirmed and updates status.
         """
+        self.isCancelled = False
         self.status = "confirmed"
 
     def request_appointment(self):
         """
         Marks the appointment as requested and updates status.
         """
+        self.isCancelled = False
         self.status = "requested"
 
     def __str__(self):

--- a/breeze/models/mhwp.py
+++ b/breeze/models/mhwp.py
@@ -89,6 +89,8 @@ class MHWP(User):
         print(
             f"\nUpcoming Calendar for {self.get_username()} in the next five working days ({date_range}):"
         )
+        print("Number of appointments:", len(self.get_appointments()))
+
         print("+", "-" * (10 + 17 * len(next_available_days)), "+")
 
         print(f"| {'Time':<10}", end=" | ")
@@ -141,9 +143,14 @@ class MHWP(User):
 
 if __name__ == "__main__":
     gp1 = MHWP(username="gp1", password="")
-    app1 = AppointmentEntry("2024-11-21", "10:00 AM")
+    app1 = AppointmentEntry("2024-11-22", "10:00 AM")
+    app2 = AppointmentEntry("2024-11-25", "11:00 AM")
     gp1.add_appointment(app1)
+    gp1.add_appointment(app2)
     app1.request_appointment()
-    print(gp1.get_appointments()[0])
-    print(gp1.get_appointment_by_date_time("2024-11-21", "10:00 AM"))
+    app2.confirm_appointment()
+    print(gp1.get_appointments())
+    print("app1:", gp1.get_appointment_by_date_time("2024-11-22", "10:00 AM"))
+    print("app2:", gp1.get_appointment_by_date_time("2024-11-23", "11:00 AM"))
+
     gp1.display_calendar()

--- a/breeze/models/mhwp.py
+++ b/breeze/models/mhwp.py
@@ -67,7 +67,7 @@ class MHWP(User):
                 return app
         return None
 
-    def display_calendar(self, code_map=None):
+    def display_calendar(self, code_map=None, is_MHWP_view=True):
         """
         Displays the calendar with dates as columns and time slots as rows for this MHWP.
         """
@@ -106,7 +106,10 @@ class MHWP(User):
                 day_slot = code_map[code]
 
                 app = self.get_appointment_by_date_time(day_slot[0], day_slot[1])
-                placeholder = app.get_status() if app else code
+                if is_MHWP_view:
+                    placeholder = app.get_status() if app else '\u25CB'
+                else:
+                    placeholder = app.get_status() if app else code
                 print(f"{placeholder:<14}", end=" | ")
             print()
 
@@ -153,4 +156,4 @@ if __name__ == "__main__":
     print("app1:", gp1.get_appointment_by_date_time("2024-11-22", "10:00 AM"))
     print("app2:", gp1.get_appointment_by_date_time("2024-11-23", "11:00 AM"))
 
-    gp1.display_calendar()
+    gp1.display_calendar(is_MHWP_view=True)

--- a/breeze/models/patient.py
+++ b/breeze/models/patient.py
@@ -1,47 +1,76 @@
 from .user import User
 
+
 class Patient(User):
-    def __init__(self, username, password, first_name = None, last_name = None, email=None, emergency_contact_email=None, is_disabled=False, mood_entries=[], journal_entries=[], appointments=[], assigned_MHWP = None):
-        super().__init__(username, password, role="Patient", first_name= first_name, last_name= last_name, email= email, is_disabled=is_disabled)
+    def __init__(
+        self,
+        username,
+        password,
+        first_name=None,
+        last_name=None,
+        email=None,
+        emergency_contact_email=None,
+        is_disabled=False,
+        mood_entries=[],
+        journal_entries=[],
+        appointments=[],
+        assigned_MHWP=None,
+    ):
+        super().__init__(
+            username,
+            password,
+            role="Patient",
+            first_name=first_name,
+            last_name=last_name,
+            email=email,
+            is_disabled=is_disabled,
+        )
         self.__emergency_contact_email = emergency_contact_email
         self.__mood_entries = mood_entries
         self.__journal_entries = journal_entries
         self.__appointments = appointments
         self.__assigned_mhwp = assigned_MHWP
-    
+
     def get_emergency_contact(self):
         return self.__emergency_contact_email
-    
+
     def set_emergency_contact(self, email):
         self.__emergency_contact_email = email
-    
+
     def get_mood_entries(self):
         return self.__mood_entries
 
     def get_appointments(self):
         return self.__appointments
-    
+
     def set_appointments(self, appointments):
         self.__appointments = appointments
+    
+    def add_appointment(self, appointment):
+        self.__appointments.append(appointment)
 
     def add_mood_entry(self, mood, comment, datetime):
-        self.__mood_entries.append({"mood": mood, "comment": comment, "datetime": datetime})
-    
+        self.__mood_entries.append(
+            {"mood": mood, "comment": comment, "datetime": datetime}
+        )
+
     def add_journal_entry(self, title, entry, datetime):
-        self.__journal_entries.append({"title": title, "entry": entry, "datetime": datetime})
-    
+        self.__journal_entries.append(
+            {"title": title, "entry": entry, "datetime": datetime}
+        )
+
     def get_assigned_mhwp(self):
         return self.__assigned_mhwp
 
     def set_assigned_mhwp(self, mhwp_username):
         self.__assigned_mhwp = mhwp_username
-    
+
     def __str__(self):
         return f"Patient: {self.get_username()}, Role: {self.get_role()}"
-    
+
     def __repr__(self):
         return f"Patient(username={self.get_username()}, role={self.get_role()})"
-    
+
     def to_dict(self):
         return {
             "username": self.get_username(),
@@ -52,10 +81,10 @@ class Patient(User):
                 "firstName": self.get_first_name(),
                 "lastName": self.get_last_name(),
                 "email": self.get_email(),
-                "emergencyContactEmail": self.get_emergency_contact()  
+                "emergencyContactEmail": self.get_emergency_contact(),
             },
             "assignedMHWP": self.get_assigned_mhwp(),
             "moods": self.__mood_entries,
             "journals": self.__journal_entries,
-            "appointments": [app.get_id() for app in self.get_appointments()]
+            "appointments": [app.get_id() for app in self.get_appointments()],
         }

--- a/breeze/services/mhwp_service.py
+++ b/breeze/services/mhwp_service.py
@@ -1,8 +1,14 @@
+import time
+from breeze.utils.appointment_utils import (
+    handle_appointment_action,
+    show_upcoming_appointments,
+)
 from breeze.utils.cli_utils import (
+    clear_screen_and_show_banner,
     print_system_message,
     clear_screen,
     direct_to_dashboard,
-    show_disabled_account_dashboard_menu
+    show_disabled_account_dashboard_menu,
 )
 from breeze.utils.constants import MHWP_BANNER_STRING
 
@@ -54,15 +60,79 @@ class MHWPService:
         return False
 
     def view_calendar(self, user):
-        clear_screen()
-        print(MHWP_BANNER_STRING)
+        clear_screen_and_show_banner(MHWP_BANNER_STRING)
         user.display_calendar()
         print()
 
         direct_to_dashboard()
 
     def manage_appointments(self, user):
-        pass
+        def handle_action(upcoming_appointments, action, prompt):
+            """Reusable logic to handle appointment actions (cancel or confirm)."""
+            while True:
+                clear_screen_and_show_banner(MHWP_BANNER_STRING)
+                upcoming_appointments = show_upcoming_appointments(
+                    user,
+                    (
+                        lambda app: (
+                            app.get_date(),
+                            app.get_time(),
+                            app.patient_username,
+                        )
+                    ),
+                )
+
+                print(
+                    f"\nEnter the index number of the appointment you want to {action} (or type 'r' to return):"
+                )
+                selected_index_input = input("> ").strip().lower()
+
+                if selected_index_input == "r":
+                    break
+
+                try:
+                    selected_index = int(selected_index_input)
+
+                    if not handle_appointment_action(
+                        upcoming_appointments, selected_index, self.auth_service, action
+                    ):
+                        print_system_message("Action could not be completed.")
+
+                except ValueError as ve:
+                    if "invalid literal for int()" in str(ve):
+                        print_system_message("Please enter a valid number.")
+                    else:
+                        print_system_message(str(ve))
+
+                    time.sleep(0.5)
+                    continue
+
+        while True:
+            clear_screen_and_show_banner(MHWP_BANNER_STRING)
+            print(f"Hi, {user.get_username()} !")
+            upcoming_appointments = show_upcoming_appointments(
+                user,
+                (lambda app: (app.get_date(), app.get_time(), app.patient_username)),
+            )
+
+            if not upcoming_appointments:
+                time.sleep(1)
+
+            print("\nChoose one of the following options:")
+            print("\n[C] Cancel appointments\n[F] Confirm appointments\n[E] Exit\n")
+
+            selected_action = input("> ").strip().lower()
+
+            if selected_action == "c":
+                handle_action(upcoming_appointments, "cancel", "Cancel")
+            elif selected_action == "f":
+                handle_action(upcoming_appointments, "confirm", "Confirm")
+            elif selected_action == "e":
+                direct_to_dashboard()
+                break
+            else:
+                print_system_message("Please enter a valid option.")
+                time.sleep(0.5)
 
     def add_patient_information(self, user):
         pass

--- a/breeze/services/patient_service/appointment.py
+++ b/breeze/services/patient_service/appointment.py
@@ -1,2 +1,257 @@
+import time
+from breeze.models.appointment_entry import AppointmentEntry
+from breeze.utils.calendar_utils import generate_calendar_slot_code_map
+from breeze.utils.cli_utils import (
+    clear_screen,
+    direct_to_dashboard,
+    print_appointments,
+    print_system_message,
+)
+from breeze.utils.constants import PATIENT_BANNER_STRING
+
+
 def manage_appointment(user, auth_service):
-    pass
+    """
+    Allows the patient to book and manage upcoming appointments.
+    """
+
+    def show_upcoming_appointments():
+        """Displays the patient's upcoming appointments."""
+        upcoming_appointments = sorted(
+            user.get_appointments(), key=lambda app: (app.get_date(), app.get_time())
+        )
+        if upcoming_appointments:
+            print("\nHere are your upcoming appointments:")
+            print_appointments(upcoming_appointments)
+            return upcoming_appointments
+
+        else:
+            print("You have no upcoming appointment.")
+
+    def display_mhwp_selection():
+        """Displays available MHWPs for the patient to choose from."""
+        available_mhwps = [
+            user
+            for user in auth_service.get_all_users().values()
+            if user.get_role().lower() == "mhwp"
+        ]
+        if not available_mhwps:
+            print("No MHWPs are currently available.")
+            return None
+        print_mhwps_for_selection(available_mhwps, user)
+        return available_mhwps
+
+    def print_mhwps_for_selection(mhwps, user):
+        """
+        Prints an ASCII table of MHWP options for a user to choose from, displaying only the MHWP's username and
+        a flag if it is the user's assigned GP.
+
+        :param mhwps: List of MHWP objects.
+        :param user: The user object, to check if the MHWP is the assigned GP.
+        """
+        if not mhwps:
+            print("No MHWPs available for selection.")
+            return
+
+        headers = ["Username", "Assigned GP"]
+
+        rows = [
+            [
+                mhwp.get_username(),
+                "Yes" if mhwp.get_username() == user.get_assigned_mhwp() else "No",
+            ]
+            for mhwp in mhwps
+        ]
+
+        column_widths = [
+            max(len(row[i]) for row in rows + [headers]) for i in range(len(headers))
+        ]
+
+        separator = "+".join("-" * (width + 2) for width in column_widths)
+        separator = f"+{separator}+"
+
+        print(separator)
+        print(
+            "| "
+            + " | ".join(
+                header.center(width) for header, width in zip(headers, column_widths)
+            )
+            + " |"
+        )
+        print(separator)
+        for row in rows:
+            print(
+                "| "
+                + " | ".join(
+                    cell.ljust(width) for cell, width in zip(row, column_widths)
+                )
+                + " |"
+            )
+        print(separator)
+
+    def clear_screen_and_show_header():
+        clear_screen()
+        print(PATIENT_BANNER_STRING)
+
+    def confirm_user_choice(
+        on_confirm=lambda: print("Action confirmed."),
+        on_cancel=lambda: print("Action canceled."),
+    ):
+        while True:
+            print("\nPress [Y] for confirm and [N] for cancel:")
+            user_choice = input("> ").strip().lower()
+            if user_choice == "y":
+                on_confirm()
+                break
+            elif user_choice == "n":
+                on_cancel()
+                break
+
+    def handle_confirm_appointment(user, selected_mhwp, requested_app):
+        user.add_appointment(requested_app)
+        selected_mhwp.add_appointment(requested_app)
+        print("Appointment confirmed and added.")
+
+    while True:
+        clear_screen_and_show_header()
+
+        assigned_mhwp = user.get_assigned_mhwp()
+        if assigned_mhwp:
+            print(f"Your current assigned MHWP: {assigned_mhwp}.")
+        else:
+            print("Your have no assigned MHWP.")
+
+        show_upcoming_appointments()
+
+        print("\nChoose one of the following options:")
+        print("\n[B]ook an appointment\n[C]ancel an upcoming appointment\n[E]xit\n")
+        user_choice = input("> ").strip().lower()
+
+        if user_choice == "b":
+            while True:
+                clear_screen_and_show_header()
+                print("\nChoose the MHWP from the following list:")
+                available_mhwps = display_mhwp_selection()
+
+                if not available_mhwps:
+                    print_system_message("No available MHWPs to book an appointment.")
+                    continue
+
+                print("\nEnter the MHWP's username (or press [r] to cancel):")
+                selected_mhwp_username = input("> ").strip().lower()
+                if selected_mhwp_username == "r":
+                    break
+
+                selected_mhwp = next(
+                    (
+                        mhwp
+                        for mhwp in available_mhwps
+                        if mhwp.get_username() == selected_mhwp_username
+                    ),
+                    None,
+                )
+
+                if selected_mhwp:
+                    clear_screen_and_show_header()
+                    app_code_map = generate_calendar_slot_code_map()
+
+                    while True:
+                        clear_screen_and_show_header()
+                        selected_mhwp.display_calendar()
+                        print(
+                            "\nSelect the available slot from the calendar (press [r] to cancel):"
+                        )
+                        selected_slot = (
+                            input("> ").strip().upper()
+                        )  # the codes are all upper case
+
+                        if selected_slot.lower() == "r":  # but the return is lower case
+                            break
+                        elif selected_slot in app_code_map:
+                            app_date_time_tuple = app_code_map.get(selected_slot)
+                            requested_app = AppointmentEntry(
+                                app_date_time_tuple[0],
+                                app_date_time_tuple[1],
+                                mhwp_username=selected_mhwp_username,
+                                patient_username=user.get_username(),
+                            )
+                            requested_app.request_appointment()
+
+                            print("\nPlease check the details for the appointment:")
+                            print_appointments([requested_app])
+
+                            confirm_user_choice(
+                                on_confirm=lambda: handle_confirm_appointment(
+                                    user, selected_mhwp, requested_app
+                                ),
+                                on_cancel=lambda: print(
+                                    "Appointment request canceled."
+                                ),
+                            )
+                            auth_service.save_data_to_file()
+                            print_system_message(
+                                "Appointment request sent successfully!"
+                            )
+                            time.sleep(1)
+                            break
+
+                        else:
+                            print_system_message("Invalid slot, please try again!")
+                            time.sleep(0.5)
+                else:
+                    print_system_message("Cannot find this MHWP, please try again!")
+                    time.sleep(0.5)
+
+        elif user_choice == "c":
+            while True:
+                clear_screen_and_show_header()
+
+                upcoming_appointments = show_upcoming_appointments()
+
+                if not upcoming_appointments:
+                    break
+
+                print(
+                    "\nEnter the index number of the appointment you want to cancel (or type 'r' to return):"
+                )
+                selected_appointment_index = input("> ").strip().lower()
+
+                if selected_appointment_index == "r":
+                    break
+
+                try:
+                    selected_index = int(selected_appointment_index)
+                    if selected_index < 1 or selected_index > len(
+                        upcoming_appointments
+                    ):
+                        print_system_message(
+                            "Invalid appointment index number. Please try again."
+                        )
+                        time.sleep(0.5)
+                        continue
+
+                    appointment_to_cancel = upcoming_appointments[selected_index - 1]
+                    if appointment_to_cancel:
+                        print_system_message(
+                            f"Appointment {selected_index} will be canceled."
+                        )
+                        appointment_to_cancel.cancel_appointment()
+                        auth_service.save_data_to_file()
+                        time.sleep(1)
+
+                        print_system_message(
+                            f"Appointment {selected_index} has been canceled."
+                        )
+                        time.sleep(1)
+
+                except ValueError:
+                    print_system_message("Please enter a valid number.")
+                    time.sleep(0.5)
+                    continue
+
+        elif user_choice == "e":
+            direct_to_dashboard()
+            break
+        else:
+            print_system_message("Please enter a valid option.")
+            time.sleep(0.5)

--- a/breeze/utils/appointment_utils.py
+++ b/breeze/utils/appointment_utils.py
@@ -1,0 +1,72 @@
+import time
+from breeze.utils.cli_utils import print_appointments, print_system_message
+
+
+def confirm_user_choice(
+    on_confirm=lambda: print("Action confirmed."),
+    on_cancel=lambda: print("Action canceled."),
+):
+    while True:
+        print("\nPress [Y] for confirm and [N] for cancel:")
+        user_choice = input("> ").strip().lower()
+        if user_choice == "y":
+            on_confirm()
+            break
+        elif user_choice == "n":
+            on_cancel()
+            break
+
+
+def show_upcoming_appointments(
+    user, key=(lambda app: (app.get_date(), app.get_time()))
+):
+    """Displays the user's upcoming appointments."""
+    upcoming_appointments = sorted(user.get_appointments(), key=key)
+    if upcoming_appointments:
+        print("\nHere are your upcoming appointments:")
+        print_appointments(upcoming_appointments)
+        return upcoming_appointments
+    else:
+        print("You have no upcoming appointment.")
+        return []
+
+
+def handle_appointment_action(
+    upcoming_appointments, selected_index, auth_service, action="cancel"
+):
+    if action not in {"cancel", "confirm"}:
+        raise ValueError(f"Invalid action '{action}'. Must be 'cancel' or 'confirm'.")
+
+    if not (1 <= selected_index <= len(upcoming_appointments)):
+        print_system_message("Invalid appointment index. Please try again.")
+        time.sleep(0.5)
+        return False
+
+    appointment = upcoming_appointments[selected_index - 1]
+    if not appointment:
+        print_system_message("No appointment found at the given index.")
+        time.sleep(0.5)
+        return False
+
+    if action == "cancel" and appointment.get_status() == "cancelled":
+        print_system_message("This appointment is already canceled. No action needed.")
+        time.sleep(0.5)
+        return False
+    elif action == "confirm" and appointment.get_status() == "confirmed":
+        print_system_message("This appointment is already confirmed. No action needed.")
+        time.sleep(0.5)
+        return False
+
+    if action == "cancel":
+        appointment.cancel_appointment()
+    elif action == "confirm":
+        appointment.confirm_appointment()
+
+    auth_service.save_data_to_file()
+
+    print_system_message(
+        f"Appointment {selected_index} has been successfully {action}ed."
+    )
+    time.sleep(1)
+
+    return True

--- a/breeze/utils/calendar_utils.py
+++ b/breeze/utils/calendar_utils.py
@@ -46,7 +46,7 @@ def generate_time_slots(start="09:00", end="17:00", interval_minutes=30):
     return slots
 
 
-def generate_calendar_slot_code_map(next_available_days, time_slots):
+def generate_calendar_slot_code_map(next_available_days=None, time_slots=None):
     """Generates a dictionary mapping unique codes to (date, time) pairs.
 
     Args:
@@ -56,6 +56,11 @@ def generate_calendar_slot_code_map(next_available_days, time_slots):
     Returns:
         dict: A dictionary where each key is a code (e.g., "A1") and each value is a (date, time) tuple.
     """
+    if not next_available_days:
+        next_available_days = get_next_available_days()
+    if not time_slots:
+        time_slots = generate_time_slots()
+        
     codes = {}
     for i, slot in enumerate(time_slots):
         col_code = chr(ord("A") + i)

--- a/breeze/utils/cli_utils.py
+++ b/breeze/utils/cli_utils.py
@@ -1,5 +1,6 @@
 import os
 
+
 def print_system_message(message):
     """Print the system message in a box that dynamically sizes according to the length of the message.
 
@@ -7,40 +8,47 @@ def print_system_message(message):
         message (str): the system message you want to display
     """
     lines = message.splitlines()
-    
+
     # Determine the maximum width based on the longest line
     max_width = max(len(line) for line in lines) + 4  # 4 for padding and borders
-    
+
     print("-" * max_width)
-    
+
     # Print each line with padding
     for line in lines:
         print(f"| {line.ljust(max_width - 4)} |")  # Align text to the left with padding
-    
+
     print("-" * max_width)
- 
+
+
 def clear_screen():
-    os.system('cls' if os.name == 'nt' else 'clear')
-    
+    os.system("cls" if os.name == "nt" else "clear")
+
+
 def show_disabled_account_dashboard_menu(username):
     """
     Prompts the user with a message when their account is disabled.
-    
+
     Args:
         user (User): The user whose account is disabled.
-        
+
     Returns:
         bool: True if the user chose to log out, otherwise False.
     """
-    print_system_message(f'Hi {username}, your account has been disabled, please contact the admin for more info!')
+    print_system_message(
+        f"Hi {username}, your account has been disabled, please contact the admin for more info!"
+    )
     print("[X] Log out")
-            
-    user_input = input('> ')
+
+    user_input = input("> ")
     if user_input.strip().lower() == "x":
         return True
     else:
-        print_system_message("Sorry, you can only log out because your account is disabled.")
+        print_system_message(
+            "Sorry, you can only log out because your account is disabled."
+        )
         return False
+
 
 def direct_to_dashboard(message=""):
     """
@@ -52,7 +60,7 @@ def direct_to_dashboard(message=""):
     if message:
         print(f"\n{message}")
     print("Please press B to go back to the dashboard.")
-    
+
     while True:
         user_input = input("> ").strip().lower()
         if user_input == "b":
@@ -60,7 +68,54 @@ def direct_to_dashboard(message=""):
             break
         else:
             print("Invalid input. Please press B to go back to the dashboard.")
-    
+
+
 def return_to_previous(string, param):
-    if string.strip().lower()==param:
+    if string.strip().lower() == param:
         return True
+
+
+def print_appointments(appointments=[]):
+    if not appointments:
+        print("No upcoming appointments.")
+        return
+
+    headers = ["#", "Date", "Time", "Status", "Cancelled", "Patient", "MHWP"]
+
+    rows = [
+        [
+            index + 1,
+            app.date,
+            app.time,
+            app.status,
+            "Yes" if app.isCancelled else "No",
+            app.patient_username,
+            app.mhwp_username,
+        ]
+        for index, app in enumerate(appointments)
+    ]
+
+    column_widths = [
+        max(len(str(row[i])) for row in rows + [headers]) for i in range(len(headers))
+    ]
+    separator = "+".join("-" * (width + 2) for width in column_widths)
+    separator = f"+{separator}+"
+
+    print(separator)
+    print(
+        "| "
+        + " | ".join(
+            header.center(width) for header, width in zip(headers, column_widths)
+        )
+        + " |"
+    )
+    print(separator)
+    for row in rows:
+        print(
+            "| "
+            + " | ".join(
+                str(cell).ljust(width) for cell, width in zip(row, column_widths)
+            )
+            + " |"
+        )
+    print(separator)

--- a/breeze/utils/cli_utils.py
+++ b/breeze/utils/cli_utils.py
@@ -119,3 +119,8 @@ def print_appointments(appointments=[]):
             + " |"
         )
     print(separator)
+
+
+def clear_screen_and_show_banner(banner_str):
+    clear_screen()
+    print(banner_str)


### PR DESCRIPTION
**Patient book/cancel appointment:**  
- Show all upcoming appointments (those on or after today).  

booking
- **Booking:** Choose a GP first; it will indicate if the GP is your assigned one.  
- **Booking:** Then show the GP's calendar, where the user can enter the slot code to book.  
- **Booking:** Show the appointment details and ask for confirmation.  

![image](https://github.com/user-attachments/assets/4187a1f7-757b-4162-81d7-5ddb4cae2b68)  
![image](https://github.com/user-attachments/assets/d76a9912-f455-44c4-862d-2dbd356f43eb)  
![image](https://github.com/user-attachments/assets/e7ce695e-d78c-4503-9a16-4382378e954f)  

cancel
- Upcoming appointments are sorted by date and time.  
- **Cancel:** Choose the appointment by the index shown in the table.  
- **Cancel:** If already canceled, you cannot cancel it again.  

**GP confirm and cancel appointment:**  
- Both workflows are the same as the cancel appointment workflow described above.  
- Show all upcoming appointments (those on or after today), sorted by date, time, and patient username.  

**TODO:**  
- Improve the table? Just realised we can use Unicode characters for a better design.  
- Any ideas for more functionalities? Maybe past GP/patient appointment history?  
  - View past appointments?  
  - Add sorting options for them?  
